### PR TITLE
bq wrappers for sendto and recvfrom

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+phantom (0.14.0~pre40sky1) precise; urgency=low
+
+  * bq wrappers for sendto(2) and recvfrom(2).
+
+ -- Alexander Kharitonov <skywalker@yandex-team.ru>  Mon, 30 Jul 2012 19:37:29 +0400
+
 phantom (0.14.0~pre40) hardy; urgency=low
 
   * svn log https://svn.yandex.ru/phantom/trunk@207

--- a/pd/bq/bq_cond.C
+++ b/pd/bq/bq_cond.C
@@ -65,4 +65,14 @@ void bq_cond_t::send() {
 		impl = list->set_ready();
 }
 
+void bq_cond_t::send_all() {
+	for(wait_item_t* item = list; item; item = item->next) {
+		bq_thr_t::impl_t* item_impl = item->set_ready();
+		if(item_impl) {
+			item_impl->poke();
+		}
+	}
+	impl = NULL;
+}
+
 } // namespace pd

--- a/pd/bq/bq_cond.H
+++ b/pd/bq/bq_cond.H
@@ -38,6 +38,7 @@ public:
 	void unlock();
 
 	void send();
+	void send_all();
 	bq_err_t wait(interval_t *timeout);
 
 	friend class wait_item_t;

--- a/pd/bq/bq_cont.C
+++ b/pd/bq/bq_cont.C
@@ -65,7 +65,7 @@ unsigned int bq_spec_reserve() throw() {
 
 #if \
 	__gcc_version_current >= __gcc_version(3, 3, 0) &&  \
-	__gcc_version_current < __gcc_version(4, 7, 0) && \
+	__gcc_version_current < __gcc_version(4, 8, 0) && \
 	!defined(__arm__)
 
 struct __cxa_eh_globals {

--- a/pd/bq/bq_cont_supp.S
+++ b/pd/bq/bq_cont_supp.S
@@ -4,6 +4,10 @@
 // This library may be distributed under the terms of the GNU LGPL 2.1.
 // See the file ‘COPYING’ or ‘http://www.gnu.org/licenses/lgpl-2.1.html’.
 
+#if defined(__linux__) && defined(__ELF__)
+.section .note.GNU-stack,"",%progbits
+#endif
+
 .file "bq_cont_supp.S"
 
 #if defined(__i386__)

--- a/pd/bq/bq_util.C
+++ b/pd/bq/bq_util.C
@@ -87,6 +87,34 @@ ssize_t bq_writev(int fd, struct iovec const *vec, int count, interval_t *timeou
 	}
 }
 
+ssize_t bq_recvfrom(int fd, void *buf, size_t len, struct sockaddr *addr, socklen_t *addrlen, interval_t *timeout) {
+	while(true) {
+		ssize_t res = recvfrom(fd, buf, len, 0, addr, addrlen);
+
+		if(res < 0 && errno == EAGAIN) {
+			short int events = POLLIN;
+			if(bq_success(bq_do_poll(fd, events, timeout, "recvfrom")))
+				continue;
+		}
+
+		return res;
+	}
+}
+
+ssize_t bq_sendto(int fd, const void *buf, size_t len, const struct sockaddr *addr, socklen_t addrlen, interval_t *timeout) {
+	while(true) {
+		ssize_t res = sendto(fd, buf, len, 0, addr, addrlen);
+
+		if(res < 0 && errno == EAGAIN) {
+			short int events = POLLOUT;
+			if(bq_success(bq_do_poll(fd, events, timeout, "sendto")))
+				continue;
+		}
+
+		return res;
+	}
+}
+
 int bq_connect(int fd, struct sockaddr const *addr, socklen_t addrlen, interval_t *timeout) {
 	int res = connect(fd, addr, addrlen);
 

--- a/pd/bq/bq_util.H
+++ b/pd/bq/bq_util.H
@@ -25,6 +25,9 @@ ssize_t bq_readv(int fd, struct iovec const *vec, int count, interval_t *timeout
 ssize_t bq_write(int fd, void const *buf, size_t len, interval_t *timeout);
 ssize_t bq_writev(int fd, struct iovec const *vec, int count, interval_t *timeout);
 
+ssize_t bq_recvfrom(int fd, void *buf, size_t len, struct sockaddr *addr, socklen_t *addrlen, interval_t *timeout);
+ssize_t bq_sendto(int fd, const void *buf, size_t len, const struct sockaddr *dest_addr, socklen_t addrlen, interval_t *timeout);
+
 ssize_t bq_sendfile(int fd, int from_fd, off_t &off, size_t size, interval_t *timeout);
 
 int bq_connect(int fd, struct sockaddr const *addr, socklen_t addrlen, interval_t *timeout);

--- a/test/bq/align.C
+++ b/test/bq/align.C
@@ -32,6 +32,7 @@ bq_spec_decl(int, sp2);
 
 char md[16];
 
+#pragma GCC diagnostic ignored "-Wuninitialized"
 void job(void *) {
 	int k;
 	char local_md[16];
@@ -40,6 +41,7 @@ void job(void *) {
 		md[k] ^= local_md[k];
 	}
 }
+#pragma GCC diagnostic pop
 
 bq_cont_count_t cont_count(3);
 


### PR DESCRIPTION
Since bq_do_poll is now in a private header, system call bq wrappers can no more be created outside phantom.
