### PR TITLE
Cpp11 compat

### DIFF
--- a/opts.mk
+++ b/opts.mk
@@ -7,7 +7,7 @@ CC = gcc
 
 OPT ?= 3
 
-CXXSTD = -std=gnu++0x
+CXXSTD = -std=c++11
 
 define FIXZERODEPS
 $(subst %,/,$(1:.d=)): force_fixzerodeps

--- a/pd/base/config.H
+++ b/pd/base/config.H
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <pd/base/config_named_list.H>
 #include <pd/base/config_block.H>
 #include <pd/base/config_syntax.H>
@@ -453,7 +455,7 @@ typename binding_t<conf_t>::item_t *binding_t<conf_t>::list = NULL;
 	string_t config::binding_t<x_t::pref##_config_t>::sname(STRING("<" #x_t "::" #pref "_config>"))
 
 #define config_binding_value_(x_t, config_t, name) \
-static config::binding_t<x_t::config_t>::value_t<typeof(((x_t::config_t *)NULL)->*(&x_t::config_t::name))> \
+static config::binding_t<x_t::config_t>::value_t<std::remove_reference<decltype(((x_t::config_t *)NULL)->*(&x_t::config_t::name))>::type> \
 	config_binding_value_##name(STRING(#name), &x_t::config_t::name)
 
 #define config_binding_value(x_t, name) \

--- a/pd/base/config_list.H
+++ b/pd/base/config_list.H
@@ -109,7 +109,7 @@ public:
 	) :
 		size(0), items(NULL) {
 
-		for(typeof(config_list._ptr()) ptr = config_list; ptr; ++ptr)
+		for(decltype(config_list._ptr()) ptr = config_list; ptr; ++ptr)
 			++size;
 
 		items = new val_t[size];
@@ -117,7 +117,7 @@ public:
 		try {
 			val_t *p = items;
 
-			for(typeof(config_list._ptr()) ptr = config_list; ptr; ++ptr)
+			for(decltype(config_list._ptr()) ptr = config_list; ptr; ++ptr)
 				*(p++) = ptr.val();
 		}
 		catch(...) {
@@ -138,7 +138,7 @@ public:
 	) :
 		size(0), items(NULL) {
 
-		for(typeof(config_list._ptr()) ptr = config_list; ptr; ++ptr)
+		for(decltype(config_list._ptr()) ptr = config_list; ptr; ++ptr)
 			++size;
 
 		items = new val_t[size];
@@ -146,7 +146,7 @@ public:
 		try {
 			val_t *p = items;
 
-			for(typeof(config_list._ptr()) ptr = config_list; ptr; ++ptr)
+			for(decltype(config_list._ptr()) ptr = config_list; ptr; ++ptr)
 				*(p++) = cvt(ptr.val());
 		}
 		catch(...) {

--- a/pd/base/config_record.H
+++ b/pd/base/config_record.H
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <pd/base/config_block.H>
 #include <pd/base/config_syntax.H>
 
@@ -124,7 +126,7 @@ struct helper_t<record_t<val_t>> {
 	string_t config::record_t<val_t>::sname(STRING("<" #val_t ">"));
 
 #define config_record_value(val_t, name) \
-	static config::record_t<val_t>::value_t<typeof(((val_t *)NULL)->*(&val_t::name))> config_binding_value_rec_##name(&val_t::name);
+	static config::record_t<val_t>::value_t<std::remove_reference<decltype(((val_t *)NULL)->*(&val_t::name))>::type> config_binding_value_rec_##name(&val_t::name);
 
 }} // namespace pd::config
 

--- a/pd/base/config_switch.H
+++ b/pd/base/config_switch.H
@@ -143,14 +143,14 @@ protected:
 	) :
 		size(0), items(NULL) {
 
-		for(typeof(config_switch._ptr()) ptr = config_switch; ptr; ++ptr)
+		for(decltype(config_switch._ptr()) ptr = config_switch; ptr; ++ptr)
 			++size;
 
 		items = new item_t *[size];
 		item_t **p = items;
 
 		try {
-			for(typeof(config_switch._ptr()) ptr = config_switch; ptr; ++ptr)
+			for(decltype(config_switch._ptr()) ptr = config_switch; ptr; ++ptr)
 				*(p++) = new item_t(ptr.key(), ptr.val());
 		}
 		catch(...) {

--- a/pd/base/lock_guard.H
+++ b/pd/base/lock_guard.H
@@ -36,7 +36,7 @@ public:
 	inline cond_handler_t(cond_t &_cond) : cond(_cond) { cond.lock(); }
 	inline ~cond_handler_t() throw() { cond.unlock(); }
 
-	inline auto wait(interval_t *timeout) -> typeof(cond.wait(timeout)) {
+	inline auto wait(interval_t *timeout) -> decltype(cond.wait(timeout)) {
 		return cond.wait(timeout);
 	}
 

--- a/pd/pi/vector.H
+++ b/pd/pi/vector.H
@@ -6,6 +6,8 @@
 
 #pragma once
 
+#include <type_traits>
+
 #include <pd/base/assert.H>
 
 #pragma GCC visibility push(default)
@@ -31,7 +33,7 @@ public:
 	template<typename _vector_t>
 	class _ptr_t {
 		static int nothing;
-		typedef typeof(((_vector_t *)&nothing)->items[0]) _x_t;
+		typedef typename std::remove_reference<decltype(((_vector_t *)&nothing)->items[0])>::type _x_t;
 		_x_t *ptr, *bound;
 
 	public:

--- a/pd/pi/vector.H
+++ b/pd/pi/vector.H
@@ -13,9 +13,9 @@
 template<typename x_t>
 typename x_t::template _ptr_t<x_t> calc_ptr_type(x_t &);
 
-#define for_each(p, some) for(typeof(calc_ptr_type(some)) p = (some); p; ++p)
+#define for_each(p, some) for(decltype(calc_ptr_type(some)) p = (some); p; ++p)
 
-#define for_each_next(p, p0) for(typeof(p0) p = p0; ++p;)
+#define for_each_next(p, p0) for(decltype(p0) p = p0; ++p;)
 
 namespace pd {
 

--- a/phantom/io.C
+++ b/phantom/io.C
@@ -29,7 +29,7 @@ void io_t::do_exec() const {
 			::kill(::getpid(), SIGTERM);
 	};
 
-	cleanup_t<typeof(cleanup_f)> cleanup(cleanup_f);
+	cleanup_t<decltype(cleanup_f)> cleanup(cleanup_f);
 
 	run();
 }

--- a/phantom/io_benchmark/method_stream/source_random/source_random.C
+++ b/phantom/io_benchmark/method_stream/source_random/source_random.C
@@ -93,7 +93,7 @@ source_random_t::source_random_t(string_t const &name, config_t const &config) :
 
 	size_t size = 0;
 
-	for(typeof(config.headers._ptr()) ptr = config.headers; ptr; ++ptr)
+	for(decltype(config.headers._ptr()) ptr = config.headers; ptr; ++ptr)
 		size += (ptr.val().size() + 2);
 
 	size += 4;
@@ -102,7 +102,7 @@ source_random_t::source_random_t(string_t const &name, config_t const &config) :
 
 	ctor('\r')('\n');
 
-	for(typeof(config.headers._ptr()) ptr = config.headers; ptr; ++ptr)
+	for(decltype(config.headers._ptr()) ptr = config.headers; ptr; ++ptr)
 		ctor(ptr.val())('\r')('\n');
 
 	header = ctor('\r')('\n');

--- a/phantom/io_benchmark/times.C
+++ b/phantom/io_benchmark/times.C
@@ -83,7 +83,7 @@ public:
 		inline void check(in_t::ptr_t const &ptr) const {
 			interval_t last = interval::zero;
 
-			for(typeof(values._ptr()) _ptr = values; _ptr; ++_ptr) {
+			for(decltype(values._ptr()) _ptr = values; _ptr; ++_ptr) {
 				interval_t t = _ptr.val();
 
 				if(t <= last)
@@ -104,7 +104,7 @@ public:
 		inline ctor_t(config_t const &_config) throw() :
 			config(_config), list_size() {
 
-			for(typeof(config.values._ptr()) ptr = config.values; ptr; ++ptr)
+			for(decltype(config.values._ptr()) ptr = config.values; ptr; ++ptr)
 				++list_size;
 		}
 
@@ -115,7 +115,7 @@ public:
 		virtual void fill(interval_t *_steps) const throw() {
 			size_t i = list_size;
 
-			for(typeof(config.values._ptr()) ptr = config.values; ptr; ++ptr)
+			for(decltype(config.values._ptr()) ptr = config.values; ptr; ++ptr)
 				_steps[--i] = ptr.val();
 		}
 	};

--- a/phantom/io_client/io_client.C
+++ b/phantom/io_client/io_client.C
@@ -107,14 +107,14 @@ io_client_t::io_client_t(string_t const &name, config_t const &config) :
 	io_t(name, config), proto(*config.proto), pools() {
 
 	size_t size = 0;
-	for(typeof(config.links._ptr()) ptr = config.links; ptr; ++ptr)
+	for(decltype(config.links._ptr()) ptr = config.links; ptr; ++ptr)
 		++size;
 
 	pools.setup(size);
 
 	size_t i = 0;
 
-	for(typeof(config.links._ptr()) ptr = config.links; ptr; ++ptr)
+	for(decltype(config.links._ptr()) ptr = config.links; ptr; ++ptr)
 		ptr.val()->create(pools[i++], config.conn_timeout, config.remote_errors, proto);
 }
 

--- a/phantom/io_client/local/link_local.C
+++ b/phantom/io_client/local/link_local.C
@@ -56,7 +56,7 @@ public:
 		inline void check(in_t::ptr_t const &ptr) const {
 			links_t::config_t::check(ptr);
 
-			for(typeof(paths._ptr()) lptr = paths; lptr; ++lptr)
+			for(decltype(paths._ptr()) lptr = paths; lptr; ++lptr)
 				if(lptr.val().size() > netaddr_local_t::max_len())
 					config::error(ptr, "path is too long");
 		}

--- a/phantom/io_client/proto_none/instance.C
+++ b/phantom/io_client/proto_none/instance.C
@@ -111,7 +111,7 @@ void instance_t::recv_proc(bq_conn_t &conn) {
 		handler.send();
 	};
 
-	cleanup_t<typeof(cleanup_f)> cleanup(cleanup_f);
+	cleanup_t<decltype(cleanup_f)> cleanup(cleanup_f);
 
 	bq_in_t in(conn, proto.prms.ibuf_size, &stat.icount());
 	in_t::ptr_t ptr(in);
@@ -181,7 +181,7 @@ void instance_t::proc(bq_conn_t &conn) {
 		stat.send_tstate().set(send::connect);
 	};
 
-	cleanup_t<typeof(cleanup_f)> cleanup(cleanup_f);
+	cleanup_t<decltype(cleanup_f)> cleanup(cleanup_f);
 
 	log::handler_t handler(send_label);
 

--- a/phantom/io_stream/proto_http/handler_static/file_types_list.C
+++ b/phantom/io_stream/proto_http/handler_static/file_types_list.C
@@ -56,7 +56,7 @@ file_types_list_t::file_types_list_t(string_t const &, config_t const &config) :
 
 	size_t size = 0;
 
-	for(typeof(config.list._ptr()) ptr = config.list; ptr; ++ptr)
+	for(decltype(config.list._ptr()) ptr = config.list; ptr; ++ptr)
 		++size;
 
 	if(!size)
@@ -66,7 +66,7 @@ file_types_list_t::file_types_list_t(string_t const &, config_t const &config) :
 
 	item_t *iptr = items;
 
-	for(typeof(config.list._ptr()) ptr = config.list; ptr; ++ptr) {
+	for(decltype(config.list._ptr()) ptr = config.list; ptr; ++ptr) {
 		string_t const &ext = ptr.key();
 		type_config_t const &config = ptr.val();
 

--- a/phantom/setup_module.C
+++ b/phantom/setup_module.C
@@ -64,7 +64,7 @@ public:
 		inline ~config_t() throw() { }
 
 		inline void check(in_t::ptr_t const &) const {
-			for(typeof(list._ptr()) lptr = list; lptr; ++lptr) {
+			for(decltype(list._ptr()) lptr = list; lptr; ++lptr) {
 				name_t const &name = lptr.val();
 
 				// #dir "/mod_" #name ".so\0"

--- a/phantom/stat.C
+++ b/phantom/stat.C
@@ -72,7 +72,7 @@ public:
 	};
 
 	inline setup_stat_t(string_t const &, config_t const &config) throw() {
-		for(typeof(config.list._ptr()) ptr = config.list; ptr; ++ptr)
+		for(decltype(config.list._ptr()) ptr = config.list; ptr; ++ptr)
 			stat_label_t::create(ptr.val());
 	}
 };


### PR DESCRIPTION
Fix compilation with C++11 and without GNU extensions.
1. s/typeof/decltype/g in may places
2. Use std::remove_reference<>::type to avoid pointer-to-reference variable declaration.
