### PR TITLE
Support for SSL NPN negotiation

### DIFF
--- a/pd/ssl/ssl.H
+++ b/pd/ssl/ssl.H
@@ -7,6 +7,7 @@
 #pragma once
 
 #include <pd/base/string.H>
+#include <pd/base/config_list.H>
 
 #pragma GCC visibility push(default)
 
@@ -29,9 +30,11 @@ public:
 class ssl_ctx_t {
 public:
 	void *internal;
+    sarray1_t<string_t> next_protos;
+    string_t negotiated_proto;
 	enum mode_t { client, server };
 
-	ssl_ctx_t(mode_t _mode, ssl_auth_t const *auth, string_t const &ciphers);
+	ssl_ctx_t(mode_t _mode, ssl_auth_t const *auth, string_t const &ciphers, config::list_t<string_t> const &protos);
 
 	~ssl_ctx_t() throw();
 

--- a/phantom/io_benchmark/method_stream/transport_ssl/transport_ssl.C
+++ b/phantom/io_benchmark/method_stream/transport_ssl/transport_ssl.C
@@ -14,6 +14,7 @@
 #include <pd/bq/bq_spec.H>
 
 #include <pd/base/config.H>
+#include <pd/base/config_list.H>
 #include <pd/base/fd.H>
 #include <pd/base/log.H>
 
@@ -50,8 +51,9 @@ public:
 		config::objptr_t<auth_t> auth;
 		string_t ciphers;
 		interval_t timeout;
+		config::list_t<string_t> protos;
 
-		inline config_t() : auth(), ciphers(), timeout(interval::second) { }
+		inline config_t() : auth(), ciphers(), timeout(interval::second), protos() { }
 
 		inline ~config_t() throw() { }
 
@@ -59,7 +61,7 @@ public:
 	};
 
 	inline transport_ssl_t(string_t const &, config_t const &config) :
-		transport_t(), ctx(ssl_ctx_t::client, config.auth, config.ciphers),
+		transport_t(), ctx(ssl_ctx_t::client, config.auth, config.ciphers, config.protos),
 		timeout(config.timeout) { }
 
 	inline ~transport_ssl_t() throw() { }
@@ -73,6 +75,7 @@ config_binding_type(transport_ssl_t, auth_t);
 config_binding_value(transport_ssl_t, auth);
 config_binding_value(transport_ssl_t, ciphers);
 config_binding_value(transport_ssl_t, timeout);
+config_binding_value(transport_ssl_t, protos);
 config_binding_cast(transport_ssl_t, transport_t);
 config_binding_ctor(transport_t, transport_ssl_t);
 }

--- a/phantom/io_stream/transport_ssl/transport_ssl.C
+++ b/phantom/io_stream/transport_ssl/transport_ssl.C
@@ -11,6 +11,7 @@
 #include <pd/ssl/bq_conn_ssl.H>
 
 #include <pd/base/config.H>
+#include <pd/base/config_list.H>
 #include <pd/base/fd.H>
 #include <pd/base/exception.H>
 
@@ -36,8 +37,9 @@ public:
 		config::objptr_t<auth_t> auth;
 		string_t ciphers;
 		interval_t timeout;
+        config::list_t<string_t> protos;
 
-		inline config_t() throw() : auth(), ciphers(), timeout(interval::second) { }
+		inline config_t() throw() : auth(), ciphers(), timeout(interval::second), protos() { }
 		inline ~config_t() throw() { }
 
 		inline void check(in_t::ptr_t const &ptr) const {
@@ -47,7 +49,7 @@ public:
 	};
 
 	inline transport_ssl_t(string_t const &, config_t const &config) throw() :
-		ctx(ssl_ctx_t::server, config.auth, config.ciphers),
+		ctx(ssl_ctx_t::server, config.auth, config.ciphers, config.protos),
 		timeout(config.timeout) { }
 
 	inline ~transport_ssl_t() throw() { }
@@ -59,6 +61,7 @@ config_binding_type(transport_ssl_t, auth_t);
 config_binding_value(transport_ssl_t, auth);
 config_binding_value(transport_ssl_t, ciphers);
 config_binding_value(transport_ssl_t, timeout);
+config_binding_value(transport_ssl_t, protos);
 config_binding_cast(transport_ssl_t, transport_t);
 config_binding_ctor(transport_t, transport_ssl_t);
 }


### PR DESCRIPTION
To properly support SPDY/HTTP2 over SSL we need TLS NPN.

Client side only for now.

Example of usage:
        transport_t ssl_transport = transport_ssl_t {
            protos = { "spdy/3.1" "spdy/3" "spdy/2" }
        }
